### PR TITLE
fix: activity cron creates PR instead of direct push

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -27,18 +27,30 @@ jobs:
         env:
           ACTIVITY_TOKEN: ${{ secrets.ACTIVITY_TOKEN }}
 
-      - name: Create PR with updated activity data
-        id: cpr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: 'chore: update GitHub activity data'
-          branch: chore/update-activity-data
-          title: 'chore: update GitHub activity data'
-          body: Automated daily update of GitHub activity data for the particle system.
-          delete-branch: true
-
-      - name: Enable auto-merge
-        if: steps.cpr.outputs.pull-request-number
-        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --auto --squash
+      - name: Create PR if data changed
         env:
           GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet data/activity.json; then
+            echo "No changes to activity data"
+            exit 0
+          fi
+
+          BRANCH="chore/update-activity-data"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add data/activity.json
+          git commit -m "chore: update GitHub activity data"
+          git push -f origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --title "chore: update GitHub activity data" \
+              --body "Automated daily update of GitHub activity data for the particle system." \
+              --head "$BRANCH"
+            EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+          fi
+
+          gh pr merge "$EXISTING_PR" --auto --squash

--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -28,6 +28,7 @@ jobs:
           ACTIVITY_TOKEN: ${{ secrets.ACTIVITY_TOKEN }}
 
       - name: Create PR with updated activity data
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: 'chore: update GitHub activity data'
@@ -35,3 +36,9 @@ jobs:
           title: 'chore: update GitHub activity data'
           body: Automated daily update of GitHub activity data for the particle system.
           delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --auto --squash
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -11,6 +11,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -26,9 +27,11 @@ jobs:
         env:
           ACTIVITY_TOKEN: ${{ secrets.ACTIVITY_TOKEN }}
 
-      - name: Commit and push if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/activity.json
-          git diff --staged --quiet || (git commit -m "chore: update GitHub activity data" && git push)
+      - name: Create PR with updated activity data
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore: update GitHub activity data'
+          branch: chore/update-activity-data
+          title: 'chore: update GitHub activity data'
+          body: Automated daily update of GitHub activity data for the particle system.
+          delete-branch: true


### PR DESCRIPTION
The activity cron was failing because master requires PRs and signed commits. Switches to `peter-evans/create-pull-request@v7` which handles both — creates a branch, commits, and opens a PR automatically.