### PR TITLE
fix: use direct squash merge instead of auto-merge in activity workflow

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -53,4 +53,4 @@ jobs:
             EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
           fi
 
-          gh pr merge "$EXISTING_PR" --auto --squash
+          gh pr merge "$EXISTING_PR" --squash


### PR DESCRIPTION
## Problem

The Update GitHub Activity workflow has been failing since May 2 with:

```
GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)
```

## Cause

A GitHub platform change (~March 2026) causes `enablePullRequestAutoMerge` to reject requests when a PR is already in "clean" status with no required status checks or reviews to wait on.

## Fix

Replace `gh pr merge "$EXISTING_PR" --auto --squash` with `gh pr merge "$EXISTING_PR" --squash`.

Since this repo has no required status checks, `--auto` is unnecessary—the PR can merge immediately.

## Verification

Trigger the workflow manually (workflow_dispatch) after merging and confirm it completes successfully.